### PR TITLE
PR: New settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build_debug:
 	@$(COMPOSE) build --no-cache --pull
 
 run:
-	@$(COMPOSE) up --no-build
+	@$(COMPOSE) up --build
 
 restart: down run
 

--- a/back-nestjs/src/dto/gameInit.dto.ts
+++ b/back-nestjs/src/dto/gameInit.dto.ts
@@ -1,24 +1,5 @@
-import { ValidateNested, IsBoolean, IsEnum, IsString } from 'class-validator';
-import { Type } from 'class-transformer';
-import { GameDifficulty, GameMode, PowerUpSelection } from 'src/game/game.types';
-
-
-class PowerUpSelectionDTO {
-	@IsBoolean()
-	speedball: boolean;
-
-	@IsBoolean()
-	powerup_2: boolean;
-
-	@IsBoolean()
-	powerup_3: boolean;
-
-	@IsBoolean()
-	powerup_4: boolean;
-
-	@IsBoolean()
-	powerup_5: boolean;
-}
+import { IsString, IsEnum, IsArray } from 'class-validator';
+import { GameDifficulty, GameMode, PowerUpTypes } from 'src/game/game.types';
 
 export default class GameInitDTO {
 	@IsString()
@@ -30,7 +11,7 @@ export default class GameInitDTO {
 	@IsEnum(GameDifficulty)
 	difficulty: GameDifficulty;
 
-	@ValidateNested()
-	@Type(() => PowerUpSelectionDTO)
-	extras: PowerUpSelection;
+	@IsArray()
+	@IsEnum(PowerUpTypes, { each: true })
+	extras: Array<PowerUpTypes>;
 }

--- a/back-nestjs/src/dto/gameInit.dto.ts
+++ b/back-nestjs/src/dto/gameInit.dto.ts
@@ -1,0 +1,36 @@
+import { ValidateNested, IsBoolean, IsEnum, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+import { GameDifficulty, GameMode, PowerUpSelection } from 'src/game/game.types';
+
+
+class PowerUpSelectionDTO {
+	@IsBoolean()
+	speedball: boolean;
+
+	@IsBoolean()
+	powerup_2: boolean;
+
+	@IsBoolean()
+	powerup_3: boolean;
+
+	@IsBoolean()
+	powerup_4: boolean;
+
+	@IsBoolean()
+	powerup_5: boolean;
+}
+
+export default class GameInitDTO {
+	@IsString()
+	sessionToken: string;
+
+	@IsEnum(GameMode)
+	mode: GameMode;
+
+	@IsEnum(GameDifficulty)
+	difficulty: GameDifficulty;
+
+	@ValidateNested()
+	@Type(() => PowerUpSelectionDTO)
+	extras: PowerUpSelection;
+}

--- a/back-nestjs/src/errors/exceptionFilters.ts
+++ b/back-nestjs/src/errors/exceptionFilters.ts
@@ -36,7 +36,9 @@ export class GameExceptionFilter implements ExceptionFilter {
 		} catch {
 			client.emit('gameError', `Internal error: ${exception.message}`);
 			client.disconnect(true);
-			this.logger.error(`Client [${client.id} - ${client.handshake.address}] forced to disconnect`);
+			this.logger.error(
+				`Client [${client.handshake.address} - ${client.handshake.address}] forced to disconnect`,
+			);
 		}
 	}
 }

--- a/back-nestjs/src/game/game.types.ts
+++ b/back-nestjs/src/game/game.types.ts
@@ -6,6 +6,13 @@ export enum GameMode {
 	unset = 'unset',
 }
 
+export enum GameDifficulty {
+	easy = 'easy',
+	medium = 'medium',
+	hard = 'hard',
+	unset = 'unset', // This is only the case when the variable is initialised, it is always overwritten with 'single' or 'multi'
+}
+
 export enum PaddleDirection {
 	up = 'up',
 	down = 'down',
@@ -16,12 +23,20 @@ export enum PlayerIdentity {
 	opponent = 1,
 }
 
-export interface WaitingPlayer {
-	clientSocket: Socket;
-	extras: boolean;
+export interface PowerUpSelection {
+	speedball: boolean;
+	powerup_2: boolean;
+	powerup_3: boolean;
+	powerup_4: boolean;
+	powerup_5: boolean;
 }
 
-export interface Player {
+export interface WaitingPlayer {
+	clientSocket: Socket;
+	extras: PowerUpSelection;
+}
+
+export interface PlayingPlayer {
 	clientSocket: Socket;
 	intraId: number;
 	nameNick: string;

--- a/back-nestjs/src/game/game.types.ts
+++ b/back-nestjs/src/game/game.types.ts
@@ -23,17 +23,17 @@ export enum PlayerIdentity {
 	opponent = 1,
 }
 
-export interface PowerUpSelection {
-	speedball: boolean;
-	powerup_2: boolean;
-	powerup_3: boolean;
-	powerup_4: boolean;
-	powerup_5: boolean;
+export enum PowerUpTypes {
+	speedBall = 'speedBall',
+	speedPaddle = 'speedPaddle',
+	slowPaddle = 'slowPaddle',
+	shrinkPaddle = 'shrinkPaddle',
+	stretchPaddle = 'stretchPaddle',
 }
 
 export interface WaitingPlayer {
 	clientSocket: Socket;
-	extras: PowerUpSelection;
+	extras: Array<PowerUpTypes>;
 }
 
 export interface PlayingPlayer {

--- a/back-nestjs/src/game/matchmaking/matchmaking.gateway.ts
+++ b/back-nestjs/src/game/matchmaking/matchmaking.gateway.ts
@@ -32,16 +32,9 @@ export default class MatchmakingGateway implements OnGatewayDisconnect {
 	handleDisconnect(@ConnectedSocket() client: Socket): void {
 		this.matchmakingService.removePlayerFromQueue(client);
 	}
-	// export interface InitData {
-	// 	sessionToken: string;
-	// 	mode: GameMode;
-	// 	extras: boolean;
-	// }
+
 	@SubscribeMessage('waiting')
-	clientWaitingAdd(
-		@MessageBody() data: GameInitDTO,
-		@ConnectedSocket() client: Socket,
-	): void {
+	clientWaitingAdd(@MessageBody() data: GameInitDTO, @ConnectedSocket() client: Socket): void {
 		this.matchmakingService.addPlayerToQueue(client, data);
 	}
 }

--- a/back-nestjs/src/game/matchmaking/matchmaking.gateway.ts
+++ b/back-nestjs/src/game/matchmaking/matchmaking.gateway.ts
@@ -9,9 +9,9 @@ import {
 import { UseFilters } from '@nestjs/common';
 import { Server, Socket } from 'socket.io';
 
-import { GameMode } from '../game.types';
 import MatchmakingService from './matchmaking.service';
 import { GameExceptionFilter } from '../../errors/exceptionFilters';
+import GameInitDTO from 'src/dto/gameInit.dto';
 
 @WebSocketGateway({
 	namespace: process.env.WS_NS_MATCHMAKING,
@@ -39,9 +39,9 @@ export default class MatchmakingGateway implements OnGatewayDisconnect {
 	// }
 	@SubscribeMessage('waiting')
 	clientWaitingAdd(
-		@MessageBody() data: {sessionToken: string,	mode: GameMode,	extras: boolean},
+		@MessageBody() data: GameInitDTO,
 		@ConnectedSocket() client: Socket,
 	): void {
-		this.matchmakingService.addPlayerToQueue(client, data.extras);
+		this.matchmakingService.addPlayerToQueue(client, data);
 	}
 }

--- a/back-nestjs/src/game/matchmaking/matchmaking.service.ts
+++ b/back-nestjs/src/game/matchmaking/matchmaking.service.ts
@@ -55,42 +55,34 @@ export default class MatchmakingService {
 	checkNewGame(): void {
 		if (this._waitingPlayersIP.length < 2) return;
 
-
 		for (let i = 0; i < this._waitingPlayersIP.length - 1; i++) {
 			const player1: WaitingPlayer = this._waitingPlayersIP[i];
 
-			for (let j = i+1; j < this._waitingPlayersIP.length; j++) {
-
+			for (let j = i + 1; j < this._waitingPlayersIP.length; j++) {
 				const player2: WaitingPlayer = this._waitingPlayersIP[j];
 
 				if (this.doTheyMatch(player1, player2)) {
-
 					const initData: GameInitDTO = {
 						sessionToken: uuidv4(),
 						mode: GameMode.multi,
 						difficulty: GameDifficulty.unset,
 						extras: player1.extras,
 					};
-	
 					player1.clientSocket.emit('ready', initData.sessionToken); // message player1
 					player2.clientSocket.emit('ready', initData.sessionToken); // message player2
-	
+
 					this.logger.log(
 						`found players ${player1.clientSocket.id}, ${player2.clientSocket.id} - sessionToken: ${initData.sessionToken}`,
 					);
 					this.roomManager.createRoom(initData);
-					return ;
+					return;
 				}
 			}
 		}
 	}
 
 	doTheyMatch(player1: WaitingPlayer, player2: WaitingPlayer) {
-
-		return (player1.extras.speedball === player2.extras.speedball &&
-						player1.extras.powerup_2 === player2.extras.powerup_2 && 
-						player1.extras.powerup_3 === player2.extras.powerup_3 &&
-						player1.extras.powerup_4 === player2.extras.powerup_4);
+		return JSON.stringify(player1.extras) === JSON.stringify(player2.extras);
 	}
 
 	isPlayerWaiting(client: WaitingPlayer) {

--- a/back-nestjs/src/game/session/roomManager.gateway.ts
+++ b/back-nestjs/src/game/session/roomManager.gateway.ts
@@ -10,11 +10,11 @@ import {
 import { Server, Socket } from 'socket.io';
 import { UseFilters } from '@nestjs/common';
 
-import { GameMode } from '../game.types';
 import PlayerDataDTO from 'src/dto/playerData.dto';
 import PaddleDirectionDTO from 'src/dto/paddleDirection.dto';
 import RoomManagerService from './roomManager.service';
 import { GameExceptionFilter } from '../../errors/exceptionFilters';
+import GameInitDTO from 'src/dto/gameInit.dto';
 
 @WebSocketGateway({
 	namespace: process.env.WS_NS_SIMULATION,
@@ -41,13 +41,14 @@ export default class RoomManagerGateway implements OnGatewayConnection, OnGatewa
 	}
 
 	@SubscribeMessage('createRoomSinglePlayer')
-	setInitData(@MessageBody() data: { sessionToken: string, mode: GameMode, extras: boolean }): void {
+	setInitData(@MessageBody() data: GameInitDTO): void {
 		
-		this.roomManager.createRoom(data.sessionToken, data.extras, data.mode);
+		this.roomManager.createRoom(data);
 	}
 
 	@SubscribeMessage('playerLeftGame')
 	handlePlayerLeft(@ConnectedSocket() client: Socket): void {
+	
 		this.roomManager.handleDisconnect(client);
 	}
 
@@ -55,8 +56,8 @@ export default class RoomManagerGateway implements OnGatewayConnection, OnGatewa
 	addPlayer(
 		@MessageBody() data: PlayerDataDTO,
 		@ConnectedSocket() client: Socket,
-		mode: GameMode,
 	): void {
+	
 		this.roomManager.addPlayer(data.sessionToken, client, data.playerId, data.nameNick);
 	}
 

--- a/back-nestjs/src/game/session/roomManager.gateway.ts
+++ b/back-nestjs/src/game/session/roomManager.gateway.ts
@@ -30,34 +30,26 @@ export default class RoomManagerGateway implements OnGatewayConnection, OnGatewa
 	@WebSocketServer()
 	server: Server;
 
-	// Keeps a Map of SimulationService instances, one per game simulation
 	constructor(private roomManager: RoomManagerService) {}
 
 	handleConnection(): void {}
 
 	handleDisconnect(@ConnectedSocket() client: Socket): void {
-		// Called by default everytime a client disconnects to the websocket
 		this.roomManager.handleDisconnect(client);
 	}
 
 	@SubscribeMessage('createRoomSinglePlayer')
 	setInitData(@MessageBody() data: GameInitDTO): void {
-		
 		this.roomManager.createRoom(data);
 	}
 
 	@SubscribeMessage('playerLeftGame')
 	handlePlayerLeft(@ConnectedSocket() client: Socket): void {
-	
 		this.roomManager.handleDisconnect(client);
 	}
 
 	@SubscribeMessage('playerData')
-	addPlayer(
-		@MessageBody() data: PlayerDataDTO,
-		@ConnectedSocket() client: Socket,
-	): void {
-	
+	addPlayer(@MessageBody() data: PlayerDataDTO, @ConnectedSocket() client: Socket): void {
 		this.roomManager.addPlayer(data.sessionToken, client, data.playerId, data.nameNick);
 	}
 

--- a/back-nestjs/src/game/session/roomManager.module.ts
+++ b/back-nestjs/src/game/session/roomManager.module.ts
@@ -6,9 +6,9 @@ import RoomManagerService from 'src/game/session/roomManager.service';
 import ExceptionModule from 'src/errors/exception.module';
 import AppLoggerModule from 'src/log/log.module';
 import ExceptionFactory from 'src/errors/exceptionFactory.service';
-import { GameMode } from 'src/game/game.types';
 import SimulationService from 'src/game/session/simulation.service';
 import AppLoggerService from 'src/log/log.service';
+import GameInitDTO from 'src/dto/gameInit.dto';
 
 @Module({
 	imports: [AppLoggerModule, forwardRef(() => ExceptionModule)],
@@ -19,9 +19,9 @@ import AppLoggerService from 'src/log/log.service';
 		{
 			provide: 'GAME_SPAWN',
 			useFactory: (logger: AppLoggerService, thrower: ExceptionFactory, config: ConfigService) => {
-				return (sessionToken: string, mode: GameMode, extras: boolean) => {
+				return (data: GameInitDTO) => {
 					const newInstance = new SimulationService(logger, thrower, config);
-					newInstance.setInitInfo(sessionToken, mode, extras);
+					newInstance.setInitInfo(data);
 
 					return newInstance;
 				};

--- a/back-nestjs/src/game/session/roomManager.module.ts
+++ b/back-nestjs/src/game/session/roomManager.module.ts
@@ -15,8 +15,8 @@ import GameInitDTO from 'src/dto/gameInit.dto';
 	providers: [
 		RoomManagerGateway,
 		RoomManagerService,
-		//SimulationService, needs a factory to create a new instance every time
 		{
+			//SimulationService, needs a factory to create a new instance every time
 			provide: 'GAME_SPAWN',
 			useFactory: (logger: AppLoggerService, thrower: ExceptionFactory, config: ConfigService) => {
 				return (data: GameInitDTO) => {

--- a/back-nestjs/src/game/session/roomManager.service.ts
+++ b/back-nestjs/src/game/session/roomManager.service.ts
@@ -3,9 +3,10 @@ import { Socket } from 'socket.io';
 import { ConfigService } from '@nestjs/config';
 
 import SimulationService from './simulation.service';
-import { GameMode, PaddleDirection } from '../game.types';
+import { PaddleDirection } from '../game.types';
 import AppLoggerService from 'src/log/log.service';
 import ExceptionFactory from 'src/errors/exceptionFactory.service';
+import GameInitDTO from 'src/dto/gameInit.dto';
 
 @Injectable()
 export default class RoomManagerService {
@@ -16,11 +17,7 @@ export default class RoomManagerService {
 		private readonly logger: AppLoggerService,
 		@Inject(forwardRef(() => ExceptionFactory)) private readonly thrower: ExceptionFactory,
 		@Inject('GAME_SPAWN')
-		private readonly gameRoomFactory: (
-			sessionToken: string,
-			mode: GameMode,
-			extras: boolean,
-		) => SimulationService,
+		private readonly gameRoomFactory: (data: GameInitDTO) => SimulationService,
 	) {
 		this.logger.setContext(RoomManagerService.name);
 		// do not log all the emits to clients if not really necessary
@@ -28,10 +25,10 @@ export default class RoomManagerService {
 			this.logger.setLogLevels(['log', 'warn', 'error', 'fatal']);
 	}
 
-	createRoom(sessionToken: string, extras: boolean, mode: GameMode): void {
-		this.rooms.set(sessionToken, this.gameRoomFactory(sessionToken, mode, extras));
+	createRoom(data: GameInitDTO): void {
+		this.rooms.set(data.sessionToken, this.gameRoomFactory(data));
 
-		this.logger.log(`session [${sessionToken}] - creating new room, mode: ${mode}`);
+		this.logger.log(`session [${data.sessionToken}] - creating new room, mode: ${data.mode}`);
 	}
 
 	dropRoom(sessionToken: string, trace: string): void {

--- a/back-nestjs/src/game/session/simulation.service.ts
+++ b/back-nestjs/src/game/session/simulation.service.ts
@@ -46,7 +46,6 @@ export default class SimulationService {
 	private powerUpSelected: GameTypes.PowerUpType[] = new Array();
 	private paddleSpeed: number[] = [this._defaultpaddleSpeed, this._defaultpaddleSpeed];
 
-
 	private powerUpIntervalTime: number = Number(
 		this.config.get<number>('GAME_POWERUP_CYCLE_TIME', 15000),
 	);
@@ -58,14 +57,14 @@ export default class SimulationService {
 	private paddleHeights: number[] = [this._defaultPaddleHeight, this._defaultPaddleHeight];
 
 	// Power up type
-	private powerUpTypes: GameTypes.PowerUpType[] = [
-		GameTypes.PowerUpType.speedBall,
-		GameTypes.PowerUpType.speedPaddle,
-		GameTypes.PowerUpType.slowPaddle,
-		GameTypes.PowerUpType.shrinkPaddle,
-		GameTypes.PowerUpType.stretchPaddle,
-	];
-	// private powerUpTypes: GameTypes.PowerUpType[] = [GameTypes.PowerUpType.speedBall, GameTypes.PowerUpType.speedPaddle, GameTypes.PowerUpType.slowPaddle]
+	// private powerUpTypes: GameTypes.PowerUpType[] = [
+	// 	GameTypes.PowerUpType.speedBall,
+	// 	GameTypes.PowerUpType.speedPaddle,
+	// 	GameTypes.PowerUpType.slowPaddle,
+	// 	GameTypes.PowerUpType.shrinkPaddle,
+	// 	GameTypes.PowerUpType.stretchPaddle,
+	// ];
+	
 	private powerUpType: GameTypes.PowerUpType;
 	private gameStateInterval: NodeJS.Timeout = null; // loop for setting up the game
 	private gameSetupInterval: NodeJS.Timeout = null; // engine loop: data emitter to client(s)
@@ -93,6 +92,7 @@ export default class SimulationService {
 				data.sessionToken,
 				`${SimulationService.name}.${this.constructor.prototype.setInitInfo.name}()`,
 			);
+
 		this.sessionToken = data.sessionToken;
 		this.mode = data.mode;
 		this.powerUpSelected = data.extras;
@@ -461,8 +461,8 @@ export default class SimulationService {
 	}
 
 	setRandomPowerUp(): void {
-		const randomIndex = Math.floor(Math.random() * this.powerUpTypes.length); // Pick a random index
-		this.powerUpType = this.powerUpTypes[randomIndex];
+		const randomIndex = Math.floor(Math.random() * this.powerUpSelected.length); // Pick a random index
+		this.powerUpType = this.powerUpSelected[randomIndex];
 		this.logger.log(`power up of type ${GameTypes.PowerUpType[this.powerUpType]} selected`);
 	}
 
@@ -609,7 +609,7 @@ export default class SimulationService {
 					'gameError',
 					`Game interrupted, player ${this.player1.nameNick} left the game`,
 				);
-		} else if (this.player2 && this.player2.clientSocket.id === client.handshake.address) {
+		} else if (this.player2) {
 			this.logger.log(
 				`session [${this.sessionToken}] - game stopped, player ${this.player2.nameNick} left the game`,
 			);

--- a/front-vite/src/Pages/Game/GameComponent/PhaserGame/GameObjects/Ball.tsx
+++ b/front-vite/src/Pages/Game/GameComponent/PhaserGame/GameObjects/Ball.tsx
@@ -1,16 +1,13 @@
-import { GAME_BALL } from '../Game.data'
-import GameScene from '../Scenes/GameScene'
+import { GAME_BALL } from '../Game.data';
+import GameScene from '../Scenes/GameScene';
 
 export default class Ball {
-
 	private readonly radius: number = GAME_BALL.radius;
 	private _graphic: Phaser.GameObjects.Circle;
 
-
 	constructor(scene: GameScene, x: number, y: number) {
-	this._graphic = scene.add.circle(x, y, this.radius, 0x0000ff);
-
-	};
+		this._graphic = scene.add.circle(x, y, this.radius, 0x0000ff);
+	}
 
 	// Redraw the ball
 	private redraw(): void {
@@ -18,14 +15,14 @@ export default class Ball {
 		this._graphic.fillStyle(0xff0000, 1); // Set the fill style (red in this case)
 		this._graphic.fillCircle(0, 0, this.radius); // Draw the circle centered at (0, 0)
 	}
-	
+
 	// Update the ball's position
 	updatePosition(x: number, y: number): void {
 		this._graphic.setPosition(x, y); // Update the ball's position
 	}
-	
+
 	// Change the ball's color if needed
 	setColor(color: number): void {
 		this._graphic.setFillStyle(color, 1); // Update the fill style
 	}
-};
+}

--- a/front-vite/src/Pages/Game/GameComponent/PhaserGame/GameObjects/SpeedBall.tsx
+++ b/front-vite/src/Pages/Game/GameComponent/PhaserGame/GameObjects/SpeedBall.tsx
@@ -1,31 +1,30 @@
 import { GAME_BALL } from '../Game.data';
 
 export default class SpeedBall extends Phaser.GameObjects.Graphics {
-  private readonly radius: number = GAME_BALL.radius;
+	private readonly radius: number = GAME_BALL.radius;
 
-  constructor(scene: Phaser.Scene, x: number, y: number) {
-    super(scene);
+	constructor(scene: Phaser.Scene, x: number, y: number) {
+		super(scene);
 
-    // Add this graphics object to the scene
-    scene.add.existing(this);
+		// Add this graphics object to the scene
+		scene.add.existing(this);
 
-    // Set position and draw the initial circle
-    this.setPosition(x, y);
-    this.fillStyle(0xffff00, 1); // Yellow fill color
-    this.fillCircle(0, 0, this.radius);
-  }
-
-  // Update position and redraw ball with new coordinates
-  updatePosition(x: number, y: number) {
-    this.clear(); // Clear previous drawing
-    this.fillStyle(0xffff00, 1); // Reset fill color
-    this.fillCircle(0, 0, this.radius); // Redraw the ball
-    this.setPosition(x, y); // Update position
-  }
-
-	destroy(): void {
-	this.clear(); // Clear graphics (optional, not strictly necessary since destroy will handle cleanup)
-	super.destroy(); // Call the parent class's destroy method
+		// Set position and draw the initial circle
+		this.setPosition(x, y);
+		this.fillStyle(0xffff00, 1); // Yellow fill color
+		this.fillCircle(0, 0, this.radius);
 	}
 
+	// Update position and redraw ball with new coordinates
+	updatePosition(x: number, y: number) {
+		this.clear(); // Clear previous drawing
+		this.fillStyle(0xffff00, 1); // Reset fill color
+		this.fillCircle(0, 0, this.radius); // Redraw the ball
+		this.setPosition(x, y); // Update position
+	}
+
+	destroy(): void {
+		this.clear(); // Clear graphics (optional, not strictly necessary since destroy will handle cleanup)
+		super.destroy(); // Call the parent class's destroy method
+	}
 }

--- a/front-vite/src/Pages/Game/GameComponent/PhaserGame/Scenes/GameScene.tsx
+++ b/front-vite/src/Pages/Game/GameComponent/PhaserGame/Scenes/GameScene.tsx
@@ -30,11 +30,12 @@ export default class GameScene extends Phaser.Scene {
 	
 	private _sessionToken: string = '';
 	private _mode: GameTypes.GameMode = GameTypes.GameMode.unset;
+	private _difficulty: GameTypes.GameDifficulty = GameTypes.GameDifficulty.unset;
 	private _powerUpSelection: GameTypes.PowerUpSelection = {
-		speedball_active: false,
-		powerup_2_active: false,
-		powerup_3_active: false,
-		powerup_4_active: false,
+		speedball: false,
+		powerup_2: false,
+		powerup_3: false,
+		powerup_4: false,
 	};
 	private _extras: boolean = false;
 	
@@ -54,8 +55,9 @@ export default class GameScene extends Phaser.Scene {
 
 		this._sessionToken = data.sessionToken;
 		this._mode = data.mode;
+		this._difficulty = data.difficulty;
 		this._powerUpSelection = data.extras;
-		this._extras = data.extras.speedball_active;	// NB: to remove
+		this._extras = data.extras.speedball;	// NB: to remove
 
 		// Key bindings
 		this._cursors =

--- a/front-vite/src/Pages/Game/GameComponent/PhaserGame/Scenes/GameScene.tsx
+++ b/front-vite/src/Pages/Game/GameComponent/PhaserGame/Scenes/GameScene.tsx
@@ -27,13 +27,22 @@ export default class GameScene extends Phaser.Scene {
 	// Player references
 	private _id: number = -1;
 	private _nameNick: string = '';
+	
 	private _sessionToken: string = '';
+	private _mode: GameTypes.GameMode = GameTypes.GameMode.unset;
+	private _powerUpSelection: GameTypes.PowerUpSelection = {
+		speedball_active: false,
+		powerup_2_active: false,
+		powerup_3_active: false,
+		powerup_4_active: false,
+	};
+	private _extras: boolean = false;
+	
 	private _socketIO!: Socket;
 	private _gameStarted: boolean = false;
-	private _mode: GameTypes.GameMode = GameTypes.GameMode.unset;
-	private _extras: boolean = false;
 	private _gameState!: GameTypes.GameState;
 	private _powerUpActive: { [key: number]: boolean } = { 0: false, 1: false }; // Tracks if a player has the power-up
+	
 	constructor() {
 		super({ key: 'Game' });
 	}
@@ -45,7 +54,8 @@ export default class GameScene extends Phaser.Scene {
 
 		this._sessionToken = data.sessionToken;
 		this._mode = data.mode;
-		this._extras = data.extras;
+		this._powerUpSelection = data.extras;
+		this._extras = data.extras.speedball_active;	// NB: to remove
 
 		// Key bindings
 		this._cursors =
@@ -87,7 +97,7 @@ export default class GameScene extends Phaser.Scene {
 			const initData: GameTypes.InitData = {
 				sessionToken: this._sessionToken,
 				mode: this._mode,
-				extras: this._extras,
+				extras: this._powerUpSelection,
 			};
 			this.sendMsgToServer('createRoomSinglePlayer', initData);
 		}

--- a/front-vite/src/Pages/Game/GameComponent/PhaserGame/Scenes/MainMenuScene.tsx
+++ b/front-vite/src/Pages/Game/GameComponent/PhaserGame/Scenes/MainMenuScene.tsx
@@ -1,5 +1,4 @@
 import { GAME } from '../Game.data';
-import { v4 as uuidv4 } from 'uuid';
 
 import * as GameTypes from '../Types/types';
 
@@ -27,26 +26,16 @@ export default class MainMenuScene extends Phaser.Scene {
 		// sets the background
 		this._background = this.add.image(GAME.width / 2, GAME.height / 2, 'background');
 		this._background.setDisplaySize(this.scale.width, this.scale.height);
-		// Create the toggle button
-		// this.createToggleSwitch(this.scale.width - 100, 50);
-		this.createToggle(this.scale.width - 250, 50, 'Extras on', 'Extras off');
 
-		// update extra
-		this.createBtn(400, 100, 'Play [single player]').on('pointerup', () =>
-			this.scene.start('Game', {
-				sessionToken: uuidv4(),
-				mode: GameTypes.GameMode.single,
-				extras: this._extrasEnabled,
-			}),
+		this.createBtn(400, 100, 'Play [single player]')
+		.on('pointerup', () =>
+			this.scene.start('Settings', { mode: GameTypes.GameMode.single }),
 		);
-		this.createBtn(400, 150, 'Play [multi player]').on('pointerup', () =>
-			this.scene.start('Matchmaking', {
-				sessionToken: '',
-				mode: GameTypes.GameMode.multi,
-				extras: this._extrasEnabled,
-			}),
+
+		this.createBtn(400, 150, 'Play [multi player]')
+		.on('pointerup', () =>
+			this.scene.start('Settings', { mode: GameTypes.GameMode.multi }),
 		);
-		this.createBtn(400, 200, 'Settings').on('pointerup', () => this.scene.start('Settings'));
 	}
 
 	// run every frame update
@@ -69,29 +58,29 @@ export default class MainMenuScene extends Phaser.Scene {
 		return newBtn;
 	}
 
-	createToggle(x: number, y: number, onText: string, offText: string): void {
-		const toggleBtn = this.add
-			.text(x, y, offText, {
-				fontSize: '32px',
-				align: 'center',
-			})
-			.setInteractive();
+	// createToggle(x: number, y: number, onText: string, offText: string): void {
+	// 	const toggleBtn = this.add
+	// 		.text(x, y, offText, {
+	// 			fontSize: '32px',
+	// 			align: 'center',
+	// 		})
+	// 		.setInteractive();
 
-		// Change color on hover
-		toggleBtn.on('pointerover', () => toggleBtn.setStyle({ fill: '#ff0' }));
-		// Change color back when not hovered
-		toggleBtn.on('pointerout', () => toggleBtn.setStyle({ fill: '#fff' }));
+	// 	// Change color on hover
+	// 	toggleBtn.on('pointerover', () => toggleBtn.setStyle({ fill: '#ff0' }));
+	// 	// Change color back when not hovered
+	// 	toggleBtn.on('pointerout', () => toggleBtn.setStyle({ fill: '#fff' }));
 
-		// Toggle the state and update the button text
-		toggleBtn.on('pointerup', () => {
-			this._extrasEnabled = !this._extrasEnabled;
-			toggleBtn.setText(this._extrasEnabled ? onText : offText);
-			toggleBtn.setStyle({ fill: this._extrasEnabled ? '#0f0' : '#fff' }); // Green for ON, White for OFF
-		});
+	// 	// Toggle the state and update the button text
+	// 	toggleBtn.on('pointerup', () => {
+	// 		this._extrasEnabled = !this._extrasEnabled;
+	// 		toggleBtn.setText(this._extrasEnabled ? onText : offText);
+	// 		toggleBtn.setStyle({ fill: this._extrasEnabled ? '#0f0' : '#fff' }); // Green for ON, White for OFF
+	// 	});
 
-		// Initial color based on default state
-		toggleBtn.setStyle({ fill: this._extrasEnabled ? '#0f0' : '#fff' });
-	}
+	// 	// Initial color based on default state
+	// 	toggleBtn.setStyle({ fill: this._extrasEnabled ? '#0f0' : '#fff' });
+	// }
 
 	// createToggleSwitch(x: number, y: number): void {
 	// 	// Create the background for the toggle (a rounded rectangle)

--- a/front-vite/src/Pages/Game/GameComponent/PhaserGame/Scenes/MainMenuScene.tsx
+++ b/front-vite/src/Pages/Game/GameComponent/PhaserGame/Scenes/MainMenuScene.tsx
@@ -27,13 +27,11 @@ export default class MainMenuScene extends Phaser.Scene {
 		this._background = this.add.image(GAME.width / 2, GAME.height / 2, 'background');
 		this._background.setDisplaySize(this.scale.width, this.scale.height);
 
-		this.createBtn(400, 100, 'Play [single player]')
-		.on('pointerup', () =>
+		this.createBtn(400, 100, 'Play [single player]').on('pointerup', () =>
 			this.scene.start('Settings', { mode: GameTypes.GameMode.single }),
 		);
 
-		this.createBtn(400, 150, 'Play [multi player]')
-		.on('pointerup', () =>
+		this.createBtn(400, 150, 'Play [multi player]').on('pointerup', () =>
 			this.scene.start('Settings', { mode: GameTypes.GameMode.multi }),
 		);
 	}

--- a/front-vite/src/Pages/Game/GameComponent/PhaserGame/Scenes/MatchmakingScene.tsx
+++ b/front-vite/src/Pages/Game/GameComponent/PhaserGame/Scenes/MatchmakingScene.tsx
@@ -6,7 +6,7 @@ import * as GameTypes from '../Types/types';
 export default class MatchmakingScene extends Phaser.Scene {
 	private _background!: Phaser.GameObjects.Image;
 	private _socketIO!: Socket;
-	private _gameInitData: GameTypes.InitData;
+	private _gameInitData: GameTypes.InitData | null = null;
 
 	private _keyEsc!: Phaser.Input.Keyboard.Key;
 
@@ -44,13 +44,11 @@ export default class MatchmakingScene extends Phaser.Scene {
 				align: 'center',
 				color: '#fff',
 			})
-			.setInteractive();
-		// Change color on hover
-		goHomeButton.on('pointerover', () => goHomeButton.setStyle({ fill: '#ff0' }));
-		// Change color back when not hovered
-		goHomeButton.on('pointerout', () => goHomeButton.setStyle({ fill: '#fff' }));
-		// Start the main game
-		goHomeButton.on('pointerup', () => this.scene.start('MainMenu'));
+		.setInteractive()
+		.on('pointerover', () => goHomeButton.setStyle({ fill: '#ff0' }))			// Change color on hover
+		.on('pointerout', () => goHomeButton.setStyle({ fill: '#fff' }))			// Change color back when not hovered
+		.on('pointerup', () => this.scene.start('MainMenu'));									// Start the main game
+		
 		this._socketIO.emit('waiting', this._gameInitData);
 	}
 

--- a/front-vite/src/Pages/Game/GameComponent/PhaserGame/Scenes/MatchmakingScene.tsx
+++ b/front-vite/src/Pages/Game/GameComponent/PhaserGame/Scenes/MatchmakingScene.tsx
@@ -44,11 +44,11 @@ export default class MatchmakingScene extends Phaser.Scene {
 				align: 'center',
 				color: '#fff',
 			})
-		.setInteractive()
-		.on('pointerover', () => goHomeButton.setStyle({ fill: '#ff0' }))			// Change color on hover
-		.on('pointerout', () => goHomeButton.setStyle({ fill: '#fff' }))			// Change color back when not hovered
-		.on('pointerup', () => this.scene.start('MainMenu'));									// Start the main game
-		
+			.setInteractive()
+			.on('pointerover', () => goHomeButton.setStyle({ fill: '#ff0' })) // Change color on hover
+			.on('pointerout', () => goHomeButton.setStyle({ fill: '#fff' })) // Change color back when not hovered
+			.on('pointerup', () => this.scene.start('MainMenu')); // Start the main game
+
 		this._socketIO.emit('waiting', this._gameInitData);
 	}
 
@@ -65,8 +65,7 @@ export default class MatchmakingScene extends Phaser.Scene {
 		});
 
 		this._socketIO.on('ready', (sessionId: string) => {
-			
-			this._gameInitData.sessionToken = sessionId;	
+			this._gameInitData.sessionToken = sessionId;
 			this.scene.start('Game', this._gameInitData);
 		});
 

--- a/front-vite/src/Pages/Game/GameComponent/PhaserGame/Scenes/SettingsScene.tsx
+++ b/front-vite/src/Pages/Game/GameComponent/PhaserGame/Scenes/SettingsScene.tsx
@@ -1,30 +1,181 @@
 import { GAME } from '../Game.data';
+import { GameDifficulty, GameMode, PowerUpSelection } from '../Types/types';
+import { v4 as uuidv4 } from 'uuid';
 
 export default class SettingsScene extends Phaser.Scene {
 	// background texture
 	private _background!: Phaser.GameObjects.Image;
 
+	private mode: GameMode = GameMode.unset;
+	private difficulty: GameDifficulty = GameDifficulty.unset;
+
+	private powerUpSelection: PowerUpSelection = {
+		speedball: false,
+		powerup_2: false,
+		powerup_3: false,
+		powerup_4: false,
+	};
+
 	constructor() {
 		super({ key: 'Settings' });
+
 	}
-
+	
 	// executed when scene.start('Matchmaking') is called
-	init(): void {}
+	init(): void {
 
+		// this.events.on('shutdown', () => {console.log(this.mode); console.log(this.difficulty); console.log(this.powerUpSelection);}, this);
+	}
+	
 	// loading graphic assets, fired after init()
 	preload(): void {}
-
+	
 	// run after preload(), shows a basic info of the error
-	create(): void {
+	create(data: {mode: GameMode}): void {
+		
+		this.mode = data.mode;
 		// sets the background
 		this._background = this.add.image(GAME.width / 2, GAME.height / 2, 'background');
 		this._background.setDisplaySize(this.scale.width, this.scale.height);
 
-		this.add.text(400, 150, 'GAME SETTINGS', {
+		this.createLabel(400, 150, 'GAME SETTINGS');
+		
+		this.powerUpSelection = {
+			speedball: false,
+			powerup_2: false,
+			powerup_3: false,
+			powerup_4: false
+		};
+
+		this.createLabel(200, 200, 'SpeedBall:');
+		const speedBallToggle = this.add
+		.text(550, 200, 'INACTIVE', {
+			fontSize: '32px',
+			align: 'center',
+			color: '#ff0',
+		})
+		.setInteractive()
+		.on('pointerup', () => {
+			this.powerUpSelection.speedball = !this.powerUpSelection.speedball;
+			speedBallToggle.setText(this.powerUpSelection.speedball ? 'ACTIVE' : 'INACTIVE');
+			speedBallToggle.setStyle({ fill: this.powerUpSelection.speedball ? '#0f0' : '#ff0' }); // Green for ON, White for OFF
+		});
+	
+		this.createLabel(200, 250, '[TBD] powerup_2:');
+		const powerUp2Toggle = this.add
+		.text(550, 250, 'INACTIVE', {
+			fontSize: '32px',
+			align: 'center',
+			color: '#ff0',
+		})
+		.setInteractive()
+		.on('pointerup', () => {
+			this.powerUpSelection.powerup_2 = !this.powerUpSelection.powerup_2;
+			powerUp2Toggle.setText(this.powerUpSelection.powerup_2 ? 'ACTIVE' : 'INACTIVE');
+			powerUp2Toggle.setStyle({ fill: this.powerUpSelection.powerup_2 ? '#0f0' : '#ff0' }); // Green for ON, White for OFF
+		});
+
+		this.createLabel(200, 300, '[TBD] powerup_3:');
+		const powerUp3Toggle = this.add
+		.text(550, 300, 'INACTIVE', {
+			fontSize: '32px',
+			align: 'center',
+			color: '#ff0',
+		})
+		.setInteractive()
+		.on('pointerup', () => {
+			this.powerUpSelection.powerup_3 = !this.powerUpSelection.powerup_3;
+			powerUp3Toggle.setText(this.powerUpSelection.powerup_3 ? 'ACTIVE' : 'INACTIVE');
+			powerUp3Toggle.setStyle({ fill: this.powerUpSelection.powerup_3 ? '#0f0' : '#ff0' }); // Green for ON, White for OFF
+		});
+
+		this.createLabel(200, 350, '[TBD] powerup_4:');
+		const powerUp4Toggle = this.add
+		.text(550, 350, 'INACTIVE', {
+			fontSize: '32px',
+			align: 'center',
+			color: '#ff0',
+		})
+		.setInteractive()
+		.on('pointerup', () => {
+			this.powerUpSelection.powerup_4 = !this.powerUpSelection.powerup_4;
+			powerUp4Toggle.setText(this.powerUpSelection.powerup_4 ? 'ACTIVE' : 'INACTIVE');
+			powerUp4Toggle.setStyle({ fill: this.powerUpSelection.powerup_4 ? '#0f0' : '#ff0' }); // Green for ON, White for OFF
+		});
+
+		const startBtn = this.add
+		.text(500, 500, this.mode === GameMode.single ? 'START' : 'JOIN QUEUE', {
 			fontSize: '32px',
 			align: 'center',
 			color: '#fff',
+		})
+		.setInteractive()
+		.on('pointerover', () => startBtn.setStyle({ fill: '#ff0' }))
+		.on('pointerout', () => startBtn.setStyle({ fill: '#fff' }))
+		.on('pointerup', () => {
+
+			if (this.mode === GameMode.single) {
+				this.scene.start('Game', {
+					sessionToken: uuidv4(),
+					mode: this.mode,
+					extras: this.powerUpSelection,
+				});
+			} else {
+				this.scene.start('Matchmaking', {
+					sessionToken: '',
+					mode: this.mode,
+					extras: this.powerUpSelection,
+				});
+			}
 		});
+
+		if (this.mode === GameMode.single) {
+
+			this.difficulty = GameDifficulty.medium;
+	
+			this.createLabel(200, 400, 'DIFFICULTY:');
+			const easyModeToggle = this.add
+			.text(550, 400, 'EASY', {
+				fontSize: '32px',
+				align: 'center',
+				color: '#fff',
+			})
+			.setInteractive()
+			.on('pointerup', () => {
+				this.difficulty = GameDifficulty.easy;
+				easyModeToggle.setStyle({ fill: '#0f0' });
+				mediumModeToggle.setStyle({ fill: '#fff' });
+				hardModeToggle.setStyle({ fill: '#fff' });
+			});
+
+			const mediumModeToggle = this.add
+			.text(650, 400, 'MEDIUM', {
+				fontSize: '32px',
+				align: 'center',
+				color: '#0f0',
+			})
+			.setInteractive()
+			.on('pointerup', () => {
+				this.difficulty = GameDifficulty.medium;
+				easyModeToggle.setStyle({ fill: '#fff' });
+				mediumModeToggle.setStyle({ fill: '#0f0' });
+				hardModeToggle.setStyle({ fill: '#fff' });
+			});
+
+			const hardModeToggle = this.add
+			.text(800, 400, 'HARD', {
+				fontSize: '32px',
+				align: 'center',
+				color: '#fff',
+			})
+			.setInteractive()
+			.on('pointerup', () => {
+				this.difficulty = GameDifficulty.hard;
+				easyModeToggle.setStyle({ fill: '#fff' });
+				mediumModeToggle.setStyle({ fill: '#fff' });
+				hardModeToggle.setStyle({ fill: '#0f0' });
+			});
+		}
 
 		// button for going home
 		const goHomeButton = this.add
@@ -33,18 +184,47 @@ export default class SettingsScene extends Phaser.Scene {
 				align: 'center',
 				color: '#fff',
 			})
-			.setInteractive();
-
-		// Change color on hover
-		goHomeButton.on('pointerover', () => goHomeButton.setStyle({ fill: '#ff0' }));
-
-		// Change color back when not hovered
-		goHomeButton.on('pointerout', () => goHomeButton.setStyle({ fill: '#fff' }));
-
-		// moves back to main
-		goHomeButton.on('pointerup', () => this.scene.start('MainMenu'));
+			.setInteractive()
+			.on('pointerover', () => goHomeButton.setStyle({ fill: '#ff0' }))	// Change color on hover
+			.on('pointerout', () => goHomeButton.setStyle({ fill: '#fff' }))	// Change color back when not hovered
+			.on('pointerup', () => this.scene.start('MainMenu'));							// moves back to main
 	}
 
 	// run every frame update
 	update(): void {}
+
+	createLabel(pos_x: number, pos_y: number, content: string, fontSize='32px', align='center', color='#fff',): Phaser.GameObjects.Text {
+
+		const textItem = this.add.text(pos_x, pos_y, content, {
+			fontSize: fontSize,
+			align: align,
+			color: color,
+		});
+
+		return textItem;
+	}
+
+	createToggle(x: number, y: number, onText: string, offText: string, flag: boolean, callback: () => void): Phaser.GameObjects.Text {
+		
+		const toggleBtn = this.add
+			.text(x, y, offText, {
+				fontSize: '32px',
+				align: 'center',
+				color: '#ff0',
+			})
+			.setInteractive();
+
+		// Change color on hover
+		// toggleBtn.on('pointerover', () => toggleBtn.setStyle({ fill: '#fff' }));
+		// // Change color back when not hovered
+		// toggleBtn.on('pointerout', () => toggleBtn.setStyle({ fill: '#ff0' }));
+
+		// Toggle the state and update the button text
+		toggleBtn.on('pointerup', callback);
+
+		// Initial color based on default state
+		// toggleBtn.setStyle({ fill: flag ? '#0f0' : '#ff0' });
+		
+		return toggleBtn;
+	}
 }

--- a/front-vite/src/Pages/Game/GameComponent/PhaserGame/Scenes/SettingsScene.tsx
+++ b/front-vite/src/Pages/Game/GameComponent/PhaserGame/Scenes/SettingsScene.tsx
@@ -1,196 +1,151 @@
 import { GAME } from '../Game.data';
-import { GameDifficulty, GameMode, PowerUpSelection } from '../Types/types';
+import { GameDifficulty, GameMode, PowerUpSelection, PowerUpTypes } from '../Types/types';
 import { v4 as uuidv4 } from 'uuid';
 
 export default class SettingsScene extends Phaser.Scene {
 	// background texture
-	private _background!: Phaser.GameObjects.Image;
 	private _keyEsc!: Phaser.Input.Keyboard.Key;
 
 	private mode: GameMode = GameMode.unset;
 	private difficulty: GameDifficulty = GameDifficulty.unset;
 
-	private powerUpSelection: PowerUpSelection = {
-		speedball: false,
-		powerup_2: false,
-		powerup_3: false,
-		powerup_4: false,
-	};
+	private powerUpSelection: Set<PowerUpTypes> = new Set();
 
 	constructor() {
 		super({ key: 'Settings' });
-
 	}
-	
+
 	// executed when scene.start('Matchmaking') is called
 	init(): void {
-
 		this._keyEsc = this.input.keyboard!.addKey(
 			Phaser.Input.Keyboard.KeyCodes.ESC,
 		) as Phaser.Input.Keyboard.Key;
 	}
-	
+
 	// loading graphic assets, fired after init()
 	preload(): void {}
-	
+
 	// run after preload(), shows a basic info of the error
-	create(data: {mode: GameMode}): void {
-		
+	create(data: { mode: GameMode }): void {
+		// defualt setting values
+		this.powerUpSelection = new Set();
 		this.mode = data.mode;
+
 		// sets the background
-		this._background = this.add.image(GAME.width / 2, GAME.height / 2, 'background');
-		this._background.setDisplaySize(this.scale.width, this.scale.height);
+		this.add
+			.image(GAME.width / 2, GAME.height / 2, 'background')
+			.setDisplaySize(this.scale.width, this.scale.height);
 
-		this.add.text(500, 150, 'SETTINGS:', { fontSize: '32px',	align: 'center',	color: '#fff' });
-		
-		this.powerUpSelection = {
-			speedball: false,
-			powerup_2: false,
-			powerup_3: false,
-			powerup_4: false
-		};
+		this.add.text(500, 80, 'SETTINGS:', { fontSize: '40px', align: 'center', color: '#fff' });
 
-		this.add.text(250, 200, 'SpeedBall', { fontSize: '32px',	align: 'center',	color: '#fff' });
-		const speedBallToggle = this.add
-		.text(600, 200, 'INACTIVE', { fontSize: '32px',	align: 'center',	color: '#ff0' })
-		.setInteractive()
-		.on('pointerup', () => {
-			this.powerUpSelection.speedball = !this.powerUpSelection.speedball;
-			speedBallToggle.setText(this.powerUpSelection.speedball ? 'ACTIVE' : 'INACTIVE');
-			speedBallToggle.setStyle({ fill: this.powerUpSelection.speedball ? '#0f0' : '#ff0' }); // Green for ON, White for OFF
-		});
-	
-		this.add.text(250, 250, '[TBD] powerup_2', { fontSize: '32px',	align: 'center',	color: '#fff' })
-		const powerUp2Toggle = this.add
-		.text(600, 250, 'INACTIVE', { fontSize: '32px',	align: 'center',	color: '#ff0' })
-		.setInteractive()
-		.on('pointerup', () => {
-			this.powerUpSelection.powerup_2 = !this.powerUpSelection.powerup_2;
-			powerUp2Toggle.setText(this.powerUpSelection.powerup_2 ? 'ACTIVE' : 'INACTIVE');
-			powerUp2Toggle.setStyle({ fill: this.powerUpSelection.powerup_2 ? '#0f0' : '#ff0' }); // Green for ON, White for OFF
-		});
-
-		this.add.text(250, 300, '[TBD] powerup_3', { fontSize: '32px',	align: 'center',	color: '#fff' })
-		const powerUp3Toggle = this.add
-		.text(600, 300, 'INACTIVE', { fontSize: '32px', align: 'center', color: '#ff0' })
-		.setInteractive()
-		.on('pointerup', () => {
-			this.powerUpSelection.powerup_3 = !this.powerUpSelection.powerup_3;
-			powerUp3Toggle.setText(this.powerUpSelection.powerup_3 ? 'ACTIVE' : 'INACTIVE');
-			powerUp3Toggle.setStyle({ fill: this.powerUpSelection.powerup_3 ? '#0f0' : '#ff0' }); // Green for ON, White for OFF
-		});
-
-		this.add.text(250, 350, '[TBD] powerup_4', { fontSize: '32px',	align: 'center',	color: '#fff' })
-		const powerUp4Toggle = this.add
-		.text(600, 350, 'INACTIVE', {
-			fontSize: '32px',
-			align: 'center',
-			color: '#ff0',
-		})
-		.setInteractive()
-		.on('pointerup', () => {
-			this.powerUpSelection.powerup_4 = !this.powerUpSelection.powerup_4;
-			powerUp4Toggle.setText(this.powerUpSelection.powerup_4 ? 'ACTIVE' : 'INACTIVE');
-			powerUp4Toggle.setStyle({ fill: this.powerUpSelection.powerup_4 ? '#0f0' : '#ff0' }); // Green for ON, White for OFF
-		});
-
-		this.add.text(250, 400, '[TBD] powerup_5', { fontSize: '32px',	align: 'center',	color: '#fff' })
-		const powerUp5Toggle = this.add
-		.text(600, 400, 'INACTIVE', {
-			fontSize: '32px',
-			align: 'center',
-			color: '#ff0',
-		})
-		.setInteractive()
-		.on('pointerup', () => {
-			this.powerUpSelection.powerup_5 = !this.powerUpSelection.powerup_5;
-			powerUp5Toggle.setText(this.powerUpSelection.powerup_5 ? 'ACTIVE' : 'INACTIVE');
-			powerUp5Toggle.setStyle({ fill: this.powerUpSelection.powerup_5 ? '#0f0' : '#ff0' }); // Green for ON, White for OFF
-		});
+		this.createTogglePowerUp(300, 150, PowerUpTypes.speedBall);
+		this.createTogglePowerUp(300, 200, PowerUpTypes.speedPaddle);
+		this.createTogglePowerUp(300, 250, PowerUpTypes.slowPaddle);
+		this.createTogglePowerUp(300, 300, PowerUpTypes.shrinkPaddle);
+		this.createTogglePowerUp(300, 350, PowerUpTypes.stretchPaddle);
 
 		const startBtn = this.add
-		.text(500, 550, this.mode === GameMode.single ? 'START' : 'JOIN QUEUE', {
-			fontSize: '32px',
-			align: 'center',
-			color: '#0f0',
-		})
-		.setInteractive()
-		.on('pointerover', () => startBtn.setStyle({ fill: '#ff0' }))
-		.on('pointerout', () => startBtn.setStyle({ fill: '#0f0' }))
-		.on('pointerup', () => {
-
-			if (this.mode === GameMode.single) {
-				this.scene.start('Game', {
-					sessionToken: uuidv4(),
-					mode: this.mode,
-					difficulty: this.difficulty,
-					extras: this.powerUpSelection,
-				});
-			} else {
-				this.scene.start('Matchmaking', {
-					sessionToken: '',
-					mode: this.mode,
-					difficulty: GameDifficulty.unset,
-					extras: this.powerUpSelection,
-				});
-			}
-		});
+			.text(500, 550, this.mode === GameMode.single ? 'START' : 'JOIN QUEUE', {
+				fontSize: '40px',
+				align: 'center',
+				color: '#0f0',
+			})
+			.setInteractive()
+			.on('pointerover', () => startBtn.setStyle({ fill: '#ff0' }))
+			.on('pointerout', () => startBtn.setStyle({ fill: '#0f0' }))
+			.on('pointerup', () => this.startGame());
 
 		if (this.mode === GameMode.single) {
-
 			this.difficulty = GameDifficulty.medium;
-	
-			this.add.text(250, 450, 'DIFFICULTY', { fontSize: '32px',	align: 'center',	color: '#fff' })
-			
+
+			this.add.text(250, 450, 'DIFFICULTY', { fontSize: '32px', align: 'center', color: '#fff' });
+
 			const easyModeToggle = this.add
-			.text(600, 450, 'EASY', { fontSize: '32px',	align: 'center', color: '#fff' })
-			.setInteractive()
-			.on('pointerup', () => {
-				this.difficulty = GameDifficulty.easy;
-				easyModeToggle.setStyle({ fill: '#0f0' });
-				mediumModeToggle.setStyle({ fill: '#fff' });
-				hardModeToggle.setStyle({ fill: '#fff' });
-			});
+				.text(600, 450, 'EASY', { fontSize: '32px', align: 'center', color: '#fff' })
+				.setInteractive()
+				.on('pointerup', () => {
+					this.difficulty = GameDifficulty.easy;
+					easyModeToggle.setStyle({ fill: '#0f0' });
+					mediumModeToggle.setStyle({ fill: '#fff' });
+					hardModeToggle.setStyle({ fill: '#fff' });
+				});
 
 			const mediumModeToggle = this.add
-			.text(700, 450, 'MEDIUM', { fontSize: '32px',	align: 'center', color: '#0f0' })
-			.setInteractive()
-			.on('pointerup', () => {
-				this.difficulty = GameDifficulty.medium;
-				easyModeToggle.setStyle({ fill: '#fff' });
-				mediumModeToggle.setStyle({ fill: '#0f0' });
-				hardModeToggle.setStyle({ fill: '#fff' });
-			});
+				.text(700, 450, 'MEDIUM', { fontSize: '32px', align: 'center', color: '#0f0' })
+				.setInteractive()
+				.on('pointerup', () => {
+					this.difficulty = GameDifficulty.medium;
+					easyModeToggle.setStyle({ fill: '#fff' });
+					mediumModeToggle.setStyle({ fill: '#0f0' });
+					hardModeToggle.setStyle({ fill: '#fff' });
+				});
 
 			const hardModeToggle = this.add
-			.text(850, 450, 'HARD', { fontSize: '32px',	align: 'center', color: '#fff' })
-			.setInteractive()
-			.on('pointerup', () => {
-				this.difficulty = GameDifficulty.hard;
-				easyModeToggle.setStyle({ fill: '#fff' });
-				mediumModeToggle.setStyle({ fill: '#fff' });
-				hardModeToggle.setStyle({ fill: '#0f0' });
-			});
+				.text(850, 450, 'HARD', { fontSize: '32px', align: 'center', color: '#fff' })
+				.setInteractive()
+				.on('pointerup', () => {
+					this.difficulty = GameDifficulty.hard;
+					easyModeToggle.setStyle({ fill: '#fff' });
+					mediumModeToggle.setStyle({ fill: '#fff' });
+					hardModeToggle.setStyle({ fill: '#0f0' });
+				});
 		}
 
-		const goHomeButton = this.add			// button for going home
+		const goHomeButton = this.add // button for going home
 			.text(GAME.width - 150, GAME.height - 100, 'Home', {
 				fontSize: '32px',
 				align: 'center',
 				color: '#fff',
 			})
 			.setInteractive()
-			.on('pointerover', () => goHomeButton.setStyle({ fill: '#ff0' }))	// Change color on hover
-			.on('pointerout', () => goHomeButton.setStyle({ fill: '#fff' }))	// Change color back when not hovered
-			.on('pointerup', () => this.scene.start('MainMenu'));							// moves back to main
+			.on('pointerover', () => goHomeButton.setStyle({ fill: '#ff0' })) // Change color on hover
+			.on('pointerout', () => goHomeButton.setStyle({ fill: '#fff' })) // Change color back when not hovered
+			.on('pointerup', () => this.scene.start('MainMenu')); // moves back to main
 	}
 
 	// run every frame update
 	update(): void {
-
 		// Exit game with ESC
-		if (this._keyEsc.isDown) {
-			this.scene.start('MainMenu');
+		if (this._keyEsc.isDown) this.scene.start('MainMenu');
+	}
+
+	createTogglePowerUp(x: number, y: number, value: PowerUpTypes): void {
+		this.add.text(x, y, `${value}`, { fontSize: '32px', align: 'center', color: '#fff' });
+		const toggle = this.add
+			.text(x + 350, y, 'INACTIVE', {
+				fontSize: '32px',
+				align: 'center',
+				color: '#ff0',
+			})
+			.setInteractive()
+			.on('pointerup', () => {
+				if (this.powerUpSelection.has(value)) {
+					this.powerUpSelection.delete(value);
+					toggle.setText('INACTIVE');
+					toggle.setStyle({ fill: '#ff0' }); // Green for ON, White for OFF
+				} else {
+					this.powerUpSelection.add(value);
+					toggle.setText('ACTIVE');
+					toggle.setStyle({ fill: '#0f0' }); // Green for ON, White for OFF
+				}
+			});
+	}
+
+	startGame(): void {
+		if (this.mode === GameMode.single) {
+			this.scene.start('Game', {
+				sessionToken: uuidv4(),
+				mode: this.mode,
+				difficulty: this.difficulty,
+				extras: Array.from(this.powerUpSelection),
+			});
+		} else {
+			this.scene.start('Matchmaking', {
+				sessionToken: '',
+				mode: this.mode,
+				difficulty: GameDifficulty.unset,
+				extras: Array.from(this.powerUpSelection),
+			});
 		}
 	}
 }

--- a/front-vite/src/Pages/Game/GameComponent/PhaserGame/Scenes/SettingsScene.tsx
+++ b/front-vite/src/Pages/Game/GameComponent/PhaserGame/Scenes/SettingsScene.tsx
@@ -5,6 +5,7 @@ import { v4 as uuidv4 } from 'uuid';
 export default class SettingsScene extends Phaser.Scene {
 	// background texture
 	private _background!: Phaser.GameObjects.Image;
+	private _keyEsc!: Phaser.Input.Keyboard.Key;
 
 	private mode: GameMode = GameMode.unset;
 	private difficulty: GameDifficulty = GameDifficulty.unset;
@@ -24,7 +25,9 @@ export default class SettingsScene extends Phaser.Scene {
 	// executed when scene.start('Matchmaking') is called
 	init(): void {
 
-		// this.events.on('shutdown', () => {console.log(this.mode); console.log(this.difficulty); console.log(this.powerUpSelection);}, this);
+		this._keyEsc = this.input.keyboard!.addKey(
+			Phaser.Input.Keyboard.KeyCodes.ESC,
+		) as Phaser.Input.Keyboard.Key;
 	}
 	
 	// loading graphic assets, fired after init()
@@ -38,7 +41,7 @@ export default class SettingsScene extends Phaser.Scene {
 		this._background = this.add.image(GAME.width / 2, GAME.height / 2, 'background');
 		this._background.setDisplaySize(this.scale.width, this.scale.height);
 
-		this.createLabel(400, 150, 'GAME SETTINGS');
+		this.add.text(500, 150, 'SETTINGS:', { fontSize: '32px',	align: 'center',	color: '#fff' });
 		
 		this.powerUpSelection = {
 			speedball: false,
@@ -47,13 +50,9 @@ export default class SettingsScene extends Phaser.Scene {
 			powerup_4: false
 		};
 
-		this.createLabel(200, 200, 'SpeedBall:');
+		this.add.text(250, 200, 'SpeedBall', { fontSize: '32px',	align: 'center',	color: '#fff' });
 		const speedBallToggle = this.add
-		.text(550, 200, 'INACTIVE', {
-			fontSize: '32px',
-			align: 'center',
-			color: '#ff0',
-		})
+		.text(600, 200, 'INACTIVE', { fontSize: '32px',	align: 'center',	color: '#ff0' })
 		.setInteractive()
 		.on('pointerup', () => {
 			this.powerUpSelection.speedball = !this.powerUpSelection.speedball;
@@ -61,13 +60,9 @@ export default class SettingsScene extends Phaser.Scene {
 			speedBallToggle.setStyle({ fill: this.powerUpSelection.speedball ? '#0f0' : '#ff0' }); // Green for ON, White for OFF
 		});
 	
-		this.createLabel(200, 250, '[TBD] powerup_2:');
+		this.add.text(250, 250, '[TBD] powerup_2', { fontSize: '32px',	align: 'center',	color: '#fff' })
 		const powerUp2Toggle = this.add
-		.text(550, 250, 'INACTIVE', {
-			fontSize: '32px',
-			align: 'center',
-			color: '#ff0',
-		})
+		.text(600, 250, 'INACTIVE', { fontSize: '32px',	align: 'center',	color: '#ff0' })
 		.setInteractive()
 		.on('pointerup', () => {
 			this.powerUpSelection.powerup_2 = !this.powerUpSelection.powerup_2;
@@ -75,13 +70,9 @@ export default class SettingsScene extends Phaser.Scene {
 			powerUp2Toggle.setStyle({ fill: this.powerUpSelection.powerup_2 ? '#0f0' : '#ff0' }); // Green for ON, White for OFF
 		});
 
-		this.createLabel(200, 300, '[TBD] powerup_3:');
+		this.add.text(250, 300, '[TBD] powerup_3', { fontSize: '32px',	align: 'center',	color: '#fff' })
 		const powerUp3Toggle = this.add
-		.text(550, 300, 'INACTIVE', {
-			fontSize: '32px',
-			align: 'center',
-			color: '#ff0',
-		})
+		.text(600, 300, 'INACTIVE', { fontSize: '32px', align: 'center', color: '#ff0' })
 		.setInteractive()
 		.on('pointerup', () => {
 			this.powerUpSelection.powerup_3 = !this.powerUpSelection.powerup_3;
@@ -89,9 +80,9 @@ export default class SettingsScene extends Phaser.Scene {
 			powerUp3Toggle.setStyle({ fill: this.powerUpSelection.powerup_3 ? '#0f0' : '#ff0' }); // Green for ON, White for OFF
 		});
 
-		this.createLabel(200, 350, '[TBD] powerup_4:');
+		this.add.text(250, 350, '[TBD] powerup_4', { fontSize: '32px',	align: 'center',	color: '#fff' })
 		const powerUp4Toggle = this.add
-		.text(550, 350, 'INACTIVE', {
+		.text(600, 350, 'INACTIVE', {
 			fontSize: '32px',
 			align: 'center',
 			color: '#ff0',
@@ -103,27 +94,43 @@ export default class SettingsScene extends Phaser.Scene {
 			powerUp4Toggle.setStyle({ fill: this.powerUpSelection.powerup_4 ? '#0f0' : '#ff0' }); // Green for ON, White for OFF
 		});
 
-		const startBtn = this.add
-		.text(500, 500, this.mode === GameMode.single ? 'START' : 'JOIN QUEUE', {
+		this.add.text(250, 400, '[TBD] powerup_5', { fontSize: '32px',	align: 'center',	color: '#fff' })
+		const powerUp5Toggle = this.add
+		.text(600, 400, 'INACTIVE', {
 			fontSize: '32px',
 			align: 'center',
-			color: '#fff',
+			color: '#ff0',
+		})
+		.setInteractive()
+		.on('pointerup', () => {
+			this.powerUpSelection.powerup_5 = !this.powerUpSelection.powerup_5;
+			powerUp5Toggle.setText(this.powerUpSelection.powerup_5 ? 'ACTIVE' : 'INACTIVE');
+			powerUp5Toggle.setStyle({ fill: this.powerUpSelection.powerup_5 ? '#0f0' : '#ff0' }); // Green for ON, White for OFF
+		});
+
+		const startBtn = this.add
+		.text(500, 550, this.mode === GameMode.single ? 'START' : 'JOIN QUEUE', {
+			fontSize: '32px',
+			align: 'center',
+			color: '#0f0',
 		})
 		.setInteractive()
 		.on('pointerover', () => startBtn.setStyle({ fill: '#ff0' }))
-		.on('pointerout', () => startBtn.setStyle({ fill: '#fff' }))
+		.on('pointerout', () => startBtn.setStyle({ fill: '#0f0' }))
 		.on('pointerup', () => {
 
 			if (this.mode === GameMode.single) {
 				this.scene.start('Game', {
 					sessionToken: uuidv4(),
 					mode: this.mode,
+					difficulty: this.difficulty,
 					extras: this.powerUpSelection,
 				});
 			} else {
 				this.scene.start('Matchmaking', {
 					sessionToken: '',
 					mode: this.mode,
+					difficulty: GameDifficulty.unset,
 					extras: this.powerUpSelection,
 				});
 			}
@@ -133,13 +140,10 @@ export default class SettingsScene extends Phaser.Scene {
 
 			this.difficulty = GameDifficulty.medium;
 	
-			this.createLabel(200, 400, 'DIFFICULTY:');
+			this.add.text(250, 450, 'DIFFICULTY', { fontSize: '32px',	align: 'center',	color: '#fff' })
+			
 			const easyModeToggle = this.add
-			.text(550, 400, 'EASY', {
-				fontSize: '32px',
-				align: 'center',
-				color: '#fff',
-			})
+			.text(600, 450, 'EASY', { fontSize: '32px',	align: 'center', color: '#fff' })
 			.setInteractive()
 			.on('pointerup', () => {
 				this.difficulty = GameDifficulty.easy;
@@ -149,11 +153,7 @@ export default class SettingsScene extends Phaser.Scene {
 			});
 
 			const mediumModeToggle = this.add
-			.text(650, 400, 'MEDIUM', {
-				fontSize: '32px',
-				align: 'center',
-				color: '#0f0',
-			})
+			.text(700, 450, 'MEDIUM', { fontSize: '32px',	align: 'center', color: '#0f0' })
 			.setInteractive()
 			.on('pointerup', () => {
 				this.difficulty = GameDifficulty.medium;
@@ -163,11 +163,7 @@ export default class SettingsScene extends Phaser.Scene {
 			});
 
 			const hardModeToggle = this.add
-			.text(800, 400, 'HARD', {
-				fontSize: '32px',
-				align: 'center',
-				color: '#fff',
-			})
+			.text(850, 450, 'HARD', { fontSize: '32px',	align: 'center', color: '#fff' })
 			.setInteractive()
 			.on('pointerup', () => {
 				this.difficulty = GameDifficulty.hard;
@@ -177,8 +173,7 @@ export default class SettingsScene extends Phaser.Scene {
 			});
 		}
 
-		// button for going home
-		const goHomeButton = this.add
+		const goHomeButton = this.add			// button for going home
 			.text(GAME.width - 150, GAME.height - 100, 'Home', {
 				fontSize: '32px',
 				align: 'center',
@@ -191,40 +186,11 @@ export default class SettingsScene extends Phaser.Scene {
 	}
 
 	// run every frame update
-	update(): void {}
+	update(): void {
 
-	createLabel(pos_x: number, pos_y: number, content: string, fontSize='32px', align='center', color='#fff',): Phaser.GameObjects.Text {
-
-		const textItem = this.add.text(pos_x, pos_y, content, {
-			fontSize: fontSize,
-			align: align,
-			color: color,
-		});
-
-		return textItem;
-	}
-
-	createToggle(x: number, y: number, onText: string, offText: string, flag: boolean, callback: () => void): Phaser.GameObjects.Text {
-		
-		const toggleBtn = this.add
-			.text(x, y, offText, {
-				fontSize: '32px',
-				align: 'center',
-				color: '#ff0',
-			})
-			.setInteractive();
-
-		// Change color on hover
-		// toggleBtn.on('pointerover', () => toggleBtn.setStyle({ fill: '#fff' }));
-		// // Change color back when not hovered
-		// toggleBtn.on('pointerout', () => toggleBtn.setStyle({ fill: '#ff0' }));
-
-		// Toggle the state and update the button text
-		toggleBtn.on('pointerup', callback);
-
-		// Initial color based on default state
-		// toggleBtn.setStyle({ fill: flag ? '#0f0' : '#ff0' });
-		
-		return toggleBtn;
+		// Exit game with ESC
+		if (this._keyEsc.isDown) {
+			this.scene.start('MainMenu');
+		}
 	}
 }

--- a/front-vite/src/Pages/Game/GameComponent/PhaserGame/Types/types.ts
+++ b/front-vite/src/Pages/Game/GameComponent/PhaserGame/Types/types.ts
@@ -16,12 +16,12 @@ export enum PaddleDirection {
 	down = 'down',
 }
 
-export interface PowerUpSelection {
-	speedball: boolean;
-	powerup_2: boolean;
-	powerup_3: boolean;
-	powerup_4: boolean;
-	powerup_5: boolean;
+export enum PowerUpTypes {
+	speedBall = 'speedBall',
+	speedPaddle = 'speedPaddle',
+	slowPaddle = 'slowPaddle',
+	shrinkPaddle = 'shrinkPaddle',
+	stretchPaddle = 'stretchPaddle',
 }
 
 export interface GameState {
@@ -50,7 +50,7 @@ export interface InitData {
 	sessionToken: string;
 	mode: GameMode;
 	difficulty: GameDifficulty;
-	extras: PowerUpSelection;
+	extras: Array<PowerUpTypes>;
 }
 
 export interface PowerUpStatus {

--- a/front-vite/src/Pages/Game/GameComponent/PhaserGame/Types/types.ts
+++ b/front-vite/src/Pages/Game/GameComponent/PhaserGame/Types/types.ts
@@ -21,6 +21,7 @@ export interface PowerUpSelection {
 	powerup_2: boolean;
 	powerup_3: boolean;
 	powerup_4: boolean;
+	powerup_5: boolean;
 }
 
 export interface GameState {
@@ -45,6 +46,13 @@ export interface PowerUp {
 	y: number;
 }
 
+export interface InitData {
+	sessionToken: string;
+	mode: GameMode;
+	difficulty: GameDifficulty;
+	extras: PowerUpSelection;
+}
+
 export interface PowerUpStatus {
 	active: boolean;
 	player: number;
@@ -54,10 +62,4 @@ export interface PlayerData {
 	playerId: number;
 	sessionToken: string;
 	nameNick: string;
-}
-
-export interface InitData {
-	sessionToken: string;
-	mode: GameMode;
-	extras: PowerUpSelection;
 }

--- a/front-vite/src/Pages/Game/GameComponent/PhaserGame/Types/types.ts
+++ b/front-vite/src/Pages/Game/GameComponent/PhaserGame/Types/types.ts
@@ -4,9 +4,23 @@ export enum GameMode {
 	unset = 'unset', // This is only the case when the variable is initialised, it is always overwritten with 'single' or 'multi'
 }
 
+export enum GameDifficulty {
+	easy = 'easy',
+	medium = 'medium',
+	hard = 'hard',
+	unset = 'unset', // This is only the case when the variable is initialised, it is always overwritten with 'single' or 'multi'
+}
+
 export enum PaddleDirection {
 	up = 'up',
 	down = 'down',
+}
+
+export interface PowerUpSelection {
+	speedball: boolean;
+	powerup_2: boolean;
+	powerup_3: boolean;
+	powerup_4: boolean;
 }
 
 export interface GameState {
@@ -45,5 +59,5 @@ export interface PlayerData {
 export interface InitData {
 	sessionToken: string;
 	mode: GameMode;
-	extras: boolean;
+	extras: PowerUpSelection;
 }

--- a/front-vite/src/Pages/Game/GameComponent/index.tsx
+++ b/front-vite/src/Pages/Game/GameComponent/index.tsx
@@ -14,15 +14,11 @@ const GameComponent: React.FC = () => {
 		gameRef.current.registry.set('user42data', playerData);
 
 		return () => {
-				
 			if (gameRef.current) {
-				
 				if (gameRef.current.scene.isActive('Game')) {
-
 					const gameScene = gameRef.current?.scene.getScene('Game') as GameScene;
-		
-					if (gameScene)
-						gameScene.disconnect();
+
+					if (gameScene) gameScene.disconnect();
 				}
 				gameRef.current.destroy(true);
 				gameRef.current = null;


### PR DESCRIPTION
Changes:

front-end UI Game: after the mode (single or multi) is choosen, further settings may be specified: powerups (currently only speedball is supported) and difficulty (only for single mode)
back-end: added DTOs for data transmission, updated matchmaking roomManager and simulation (controllers and services) for handling complex data that represents which power-up is selected or the difficulty, for single player.
NB: currently the difficulty is supported only on the UI, it doesn't affect the reaction time of the bot (see issue https://github.com/Orpheus-3145/transcendence/issues/61 )